### PR TITLE
Fix

### DIFF
--- a/packages/client/components/Details/Details.tsx
+++ b/packages/client/components/Details/Details.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styles from "./Details.module.css";
 import { TokenType, AmmType } from "../../hooks/useContract";
 import { ethers } from "ethers";
@@ -33,22 +33,7 @@ export default function Details({
     setTokens([token0, token1]);
   }, [token0, token1]);
 
-  useEffect(() => {
-    getAmountOfUserTokens();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tokens, updateDetailsFlag]);
-
-  useEffect(() => {
-    getAmountOfPoolTokens();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amm, tokens, updateDetailsFlag]);
-
-  useEffect(() => {
-    getShare();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amm, updateDetailsFlag]);
-
-  const getAmountOfUserTokens = async () => {
+  const getAmountOfUserTokens = useCallback(async () => {
     if (!currentAccount) return;
     try {
       setAmountOfUserTokens([]);
@@ -62,9 +47,9 @@ export default function Details({
     } catch (error) {
       console.log(error);
     }
-  };
+  }, [currentAccount, tokens]);
 
-  const getAmountOfPoolTokens = async () => {
+  const getAmountOfPoolTokens = useCallback(async () => {
     if (!amm) return;
     try {
       setAmountOfPoolTokens([]);
@@ -78,9 +63,9 @@ export default function Details({
     } catch (error) {
       console.log(error);
     }
-  };
+  }, [amm, tokens]);
 
-  async function getShare() {
+  const getShare = useCallback(async () => {
     if (!amm || !currentAccount) return;
     try {
       let share = await amm.contract.share(currentAccount);
@@ -96,7 +81,19 @@ export default function Details({
     } catch (err) {
       console.log("Couldn't Fetch details", err);
     }
-  }
+  }, [amm, currentAccount]);
+
+  useEffect(() => {
+    getAmountOfUserTokens();
+  }, [getAmountOfUserTokens, updateDetailsFlag]);
+
+  useEffect(() => {
+    getAmountOfPoolTokens();
+  }, [getAmountOfPoolTokens, updateDetailsFlag]);
+
+  useEffect(() => {
+    getShare();
+  }, [getShare, updateDetailsFlag]);
 
   return (
     <div className={styles.details}>

--- a/packages/client/components/Details/Details.tsx
+++ b/packages/client/components/Details/Details.tsx
@@ -35,14 +35,17 @@ export default function Details({
 
   useEffect(() => {
     getAmountOfUserTokens();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tokens, updateDetailsFlag]);
 
   useEffect(() => {
     getAmountOfPoolTokens();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amm, tokens, updateDetailsFlag]);
 
   useEffect(() => {
     getShare();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amm, updateDetailsFlag]);
 
   const getAmountOfUserTokens = async () => {

--- a/packages/client/components/Details/Details.tsx
+++ b/packages/client/components/Details/Details.tsx
@@ -101,7 +101,7 @@ export default function Details({
         <div className={styles.detailsHeader}>Your Details</div>
         {amountOfUserTokens.map((amount, index) => {
           return (
-            <div className={styles.detailsRow}>
+            <div key={index} className={styles.detailsRow}>
               <div className={styles.detailsAttribute}>
                 {tokens[index].symbol}:
               </div>
@@ -120,7 +120,7 @@ export default function Details({
         <div className={styles.detailsHeader}>Pool Details</div>
         {amountOfPoolTokens.map((amount, index) => {
           return (
-            <div className={styles.detailsRow}>
+            <div key={index} className={styles.detailsRow}>
               <div className={styles.detailsAttribute}>
                 Total {tokens[index].symbol}:
               </div>

--- a/packages/client/components/SelectTab/Provide.tsx
+++ b/packages/client/components/SelectTab/Provide.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TokenType, AmmType } from "../../hooks/useContract";
 import styles from "./SelectTab.module.css";
 import { BigNumber, ethers } from "ethers";
@@ -25,12 +25,7 @@ export default function Provide({
   const [amountOfToken1, setAmountOfToken1] = useState("");
   const [activePool, setActivePool] = useState(true);
 
-  useEffect(() => {
-    checkLiquidity();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amm]);
-
-  const checkLiquidity = async () => {
+  const checkLiquidity = useCallback(async () => {
     if (!amm) return;
     try {
       const totalShare = await amm.contract.totalShare();
@@ -42,7 +37,11 @@ export default function Provide({
     } catch (error) {
       alert(error);
     }
-  };
+  }, [amm]);
+
+  useEffect(() => {
+    checkLiquidity();
+  }, [checkLiquidity]);
 
   const getProvideEstimate = async (
     token: TokenType,

--- a/packages/client/components/SelectTab/Provide.tsx
+++ b/packages/client/components/SelectTab/Provide.tsx
@@ -27,6 +27,7 @@ export default function Provide({
 
   useEffect(() => {
     checkLiquidity();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amm]);
 
   const checkLiquidity = async () => {

--- a/packages/client/components/SelectTab/Withdraw.tsx
+++ b/packages/client/components/SelectTab/Withdraw.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TokenType, AmmType } from "../../hooks/useContract";
 import styles from "./SelectTab.module.css";
 import { BigNumber, ethers } from "ethers";
@@ -29,12 +29,7 @@ export default function Withdraw({
   const [amountOfShare, setAmountOfShare] = useState("");
   const [amountOfMaxShare, setAmountOfMaxShare] = useState<string>();
 
-  useEffect(() => {
-    getMaxShare();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amm]);
-
-  const getMaxShare = async () => {
+  const getMaxShare = useCallback(async () => {
     if (!amm || !currentAccount) return;
     try {
       const shareWithPrecision = await amm.contract.share(currentAccount);
@@ -46,7 +41,11 @@ export default function Withdraw({
     } catch (error) {
       alert(error);
     }
-  };
+  }, [amm, currentAccount]);
+
+  useEffect(() => {
+    getMaxShare();
+  }, [getMaxShare]);
 
   const leftLessThanRightAsBigNumber = (
     left: string,

--- a/packages/client/components/SelectTab/Withdraw.tsx
+++ b/packages/client/components/SelectTab/Withdraw.tsx
@@ -31,6 +31,7 @@ export default function Withdraw({
 
   useEffect(() => {
     getMaxShare();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amm]);
 
   const getMaxShare = async () => {

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from "next";
 import styles from "../styles/Home.module.css";
 import { useWallet } from "../hooks/useWallet";
 import Container from "../components/Container/Container";
+import Image from "next/image";
 
 const Home: NextPage = () => {
   const { currentAccount, connectWallet } = useWallet();
@@ -10,7 +11,12 @@ const Home: NextPage = () => {
     <div className={styles.pageBody}>
       <div className={styles.navBar}>
         <div className={styles.rightHeader}>
-          <img src="bird.png" width="40px" height="30px" />
+          <Image
+            alt="Picture of icon"
+            src="bird.png"
+            width="40px"
+            height="30px"
+          />
           <div className={styles.appName}> Miniswap </div>
         </div>
         {currentAccount == undefined ? (

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -13,7 +13,7 @@ const Home: NextPage = () => {
         <div className={styles.rightHeader}>
           <Image
             alt="Picture of icon"
-            src="bird.png"
+            src="/bird.png"
             width="40px"
             height="30px"
           />


### PR DESCRIPTION
eslintのerror + warinig解消

104:13  Error: Missing "key" prop for element in iterator  react/jsx-key
これは複数のコンポーネントを繰り返しで作成する場合に, それぞれのコンポーネントにkey属性をつけることを強制するもの。
おそらく, レンダリングする側が各コンポーネントを区別するためにkey属性をつけるべきということ。
参考: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

13:11  Warning: Do not use <img> element. Use <Image /> from next/image instead. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
これはnext.jsにimgを最適化させたImageという機能があるのでそちらを使ってくれというもの。

38:6  Warning: React Hook useEffect has a missing dependency: 'getAmountOfUserTokens'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
これはuseEffect内で使用している関数も, 依存関係の配列に入れるべきという内容。
こちらに関しては今回問題でないので無視。